### PR TITLE
Show updatables from available updates

### DIFF
--- a/src/pages/sdk/sdk.component.ts
+++ b/src/pages/sdk/sdk.component.ts
@@ -50,6 +50,16 @@ export class SdkComponent implements OnInit {
       await this.ngOnInit();
     }
   }
+
+  async update(p: Package) {
+    if (p.state == InstallStates.Updateable) {
+      const installing = this.dialog.open(InstallDialog, { disableClose: true });
+      await installPackageAsync(this.sdkSetting, p.rawName);
+      installing.close();
+      // reload
+      await this.ngOnInit();
+    }
+  }
 }
 
 @Component({

--- a/src/pages/sdk/sdk.html
+++ b/src/pages/sdk/sdk.html
@@ -32,8 +32,11 @@
           <ng-container mdColumnDef="state">
             <md-header-cell *mdHeaderCellDef fxFlex="10"></md-header-cell>
             <md-cell *mdCellDef="let e" fxFlex="10" style="text-align: center;">
-              <ng-container *ngIf="e.state === InstallState.Installed; else b">{{e.state}}</ng-container>
-              <ng-template #b><button (click)="install(e)" md-button color="accent">Install</button></ng-template>
+              <ng-container [ngSwitch]="e.state">
+                <div *ngSwitchCase="InstallState.Installed">{{e.state}}</div>
+                <div *ngSwitchCase="InstallState.Updateable"><button (click)="update(e)" md-button color="accent">Update</button></div>
+                <div *ngSwitchDefault><button (click)="install(e)" md-button color="accent">Install</button></div>
+              </ng-container>
             </md-cell>
           </ng-container>
 

--- a/src/services/sdkmanager.ts
+++ b/src/services/sdkmanager.ts
@@ -82,7 +82,8 @@ export function parseList(stdout: string) {
       break;
     }
 
-    if (packages.findIndex(pkg => pkg.rawName === lines[pointer]) === -1) {
+    const index = packages.findIndex(pkg => pkg.rawName === lines[pointer]);
+    if (index === -1) {
       // Not installed
       const p = new Package();
       p.state = InstallStates.Available;
@@ -94,7 +95,7 @@ export function parseList(stdout: string) {
       packages.push(p);
     } else {
       // Already installed
-      const p = packages.find((value) => value.rawName == lines[pointer]);
+      const p = packages[index];
       if (p) {
         const rv = lines[pointer + 2].slice('    Remote Version: '.length).trim();
         if (cmpVersions(p.version, rv) < 0) {
@@ -109,26 +110,6 @@ export function parseList(stdout: string) {
     do {
       pointer += 1;
     } while (lines[pointer]);
-    pointer += 1;
-  }
-
-  // available updates
-  for (; pointer < lines.length; ) {
-    if (lines[pointer].startsWith('done')) {
-      break;
-    }
-
-    /*
-    const upRawName = lines[pointer];
-    const upLocalVersion = lines[pointer + 2].slice(20);
-    const upRemoteVersion = lines[pointer + 2].slice(20);
-
-    //skip
-    pointer += 2;
-    do {
-      pointer += 1;
-    } while (lines[pointer] && lines[pointer] === 'done');
-    */
     pointer += 1;
   }
 

--- a/test/assets/sdkmanager/list3.txt
+++ b/test/assets/sdkmanager/list3.txt
@@ -1,0 +1,1229 @@
+Info: Parsing /Users/k24/Library/Android/sdk/build-tools/20.0.0/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/build-tools/21.1.2/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/build-tools/22.0.1/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/build-tools/23.0.1/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/build-tools/23.0.2/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/build-tools/23.0.3/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/build-tools/24.0.0/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/build-tools/24.0.1/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/build-tools/24.0.2/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/build-tools/24.0.3/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/build-tools/25.0.0/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/build-tools/25.0.1/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/build-tools/25.0.2/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/build-tools/26.0.1/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/build-tools/26.0.2/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/emulator/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/extras/android/m2repository/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/extras/android/support/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/extras/google/m2repository/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/extras/m2repository/com/android/support/constraint/constraint-layout-solver/1.0.2/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/extras/m2repository/com/android/support/constraint/constraint-layout/1.0.2/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/patcher/v4/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/platform-tools/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/platforms/android-10/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/platforms/android-16/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/platforms/android-19/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/platforms/android-21/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/platforms/android-22/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/platforms/android-23/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/platforms/android-24/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/platforms/android-25/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/platforms/android-26/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/sources/android-22/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/sources/android-23/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/system-images/android-10/default/x86/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/system-images/android-16/default/x86/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/system-images/android-23/default/x86_64/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/system-images/android-23/google_apis/x86_64/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/system-images/android-24/default/x86_64/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/system-images/android-25/google_apis/x86_64/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/tools/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/add-ons/addon-google_apis-google-16/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/build-tools/20.0.0/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/build-tools/21.1.2/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/build-tools/22.0.1/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/build-tools/23.0.1/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/build-tools/23.0.2/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/build-tools/23.0.3/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/build-tools/24.0.0/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/build-tools/24.0.1/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/build-tools/24.0.2/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/build-tools/24.0.3/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/build-tools/25.0.0/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/build-tools/25.0.1/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/build-tools/25.0.2/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/build-tools/26.0.1/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/build-tools/26.0.2/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/emulator/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/extras/android/m2repository/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/extras/android/support/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/extras/google/m2repository/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/extras/m2repository/com/android/support/constraint/constraint-layout-solver/1.0.2/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/extras/m2repository/com/android/support/constraint/constraint-layout/1.0.2/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/patcher/v4/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/platform-tools/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/platforms/android-10/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/platforms/android-16/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/platforms/android-19/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/platforms/android-21/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/platforms/android-22/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/platforms/android-23/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/platforms/android-24/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/platforms/android-25/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/platforms/android-26/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/sources/android-22/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/sources/android-23/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/system-images/android-10/default/x86/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/system-images/android-16/default/x86/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/system-images/android-23/default/x86_64/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/system-images/android-23/google_apis/x86_64/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/system-images/android-24/default/x86_64/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/system-images/android-25/google_apis/x86_64/package.xml
+Info: Parsing /Users/k24/Library/Android/sdk/tools/package.xml
+Installed packages:
+--------------------------------------
+add-ons;addon-google_apis-google-16
+    Description:        Google APIs, Android 16, rev 4
+    Version:            4.0.0
+    Installed Location: /Users/k24/Library/Android/sdk/add-ons/addon-google_apis-google-16
+
+build-tools;20.0.0
+    Description:        Android SDK Build-Tools
+    Version:            20.0.0
+    Installed Location: /Users/k24/Library/Android/sdk/build-tools/20.0.0
+
+build-tools;21.1.2
+    Description:        Android SDK Build-Tools 21.1.2
+    Version:            21.1.2
+    Installed Location: /Users/k24/Library/Android/sdk/build-tools/21.1.2
+
+build-tools;22.0.1
+    Description:        Android SDK Build-Tools 22.0.1
+    Version:            22.0.1
+    Installed Location: /Users/k24/Library/Android/sdk/build-tools/22.0.1
+
+build-tools;23.0.1
+    Description:        Android SDK Build-Tools 23.0.1
+    Version:            23.0.1
+    Installed Location: /Users/k24/Library/Android/sdk/build-tools/23.0.1
+
+build-tools;23.0.2
+    Description:        Android SDK Build-Tools 23.0.2
+    Version:            23.0.2
+    Installed Location: /Users/k24/Library/Android/sdk/build-tools/23.0.2
+
+build-tools;23.0.3
+    Description:        Android SDK Build-Tools 23.0.3
+    Version:            23.0.3
+    Installed Location: /Users/k24/Library/Android/sdk/build-tools/23.0.3
+
+build-tools;24.0.0
+    Description:        Android SDK Build-Tools 24
+    Version:            24.0.0
+    Installed Location: /Users/k24/Library/Android/sdk/build-tools/24.0.0
+
+build-tools;24.0.1
+    Description:        Android SDK Build-Tools 24.0.1
+    Version:            24.0.1
+    Installed Location: /Users/k24/Library/Android/sdk/build-tools/24.0.1
+
+build-tools;24.0.2
+    Description:        Android SDK Build-Tools 24.0.2
+    Version:            24.0.2
+    Installed Location: /Users/k24/Library/Android/sdk/build-tools/24.0.2
+
+build-tools;24.0.3
+    Description:        Android SDK Build-Tools 24.0.3
+    Version:            24.0.3
+    Installed Location: /Users/k24/Library/Android/sdk/build-tools/24.0.3
+
+build-tools;25.0.0
+    Description:        Android SDK Build-Tools 25
+    Version:            25.0.0
+    Installed Location: /Users/k24/Library/Android/sdk/build-tools/25.0.0
+
+build-tools;25.0.1
+    Description:        Android SDK Build-Tools 25.0.1
+    Version:            25.0.1
+    Installed Location: /Users/k24/Library/Android/sdk/build-tools/25.0.1
+
+build-tools;25.0.2
+    Description:        Android SDK Build-Tools 25.0.2
+    Version:            25.0.2
+    Installed Location: /Users/k24/Library/Android/sdk/build-tools/25.0.2
+
+build-tools;26.0.1
+    Description:        Android SDK Build-Tools 26.0.1
+    Version:            26.0.1
+    Installed Location: /Users/k24/Library/Android/sdk/build-tools/26.0.1
+
+build-tools;26.0.2
+    Description:        Android SDK Build-Tools 26.0.2
+    Version:            26.0.2
+    Installed Location: /Users/k24/Library/Android/sdk/build-tools/26.0.2
+
+emulator
+    Description:        Android Emulator
+    Version:            26.0.0
+    Installed Location: /Users/k24/Library/Android/sdk/emulator
+
+extras;android;m2repository
+    Description:        Android Support Repository
+    Version:            47.0.0
+    Installed Location: /Users/k24/Library/Android/sdk/extras/android/m2repository
+
+extras;android;support
+    Description:        Android Support Library
+    Version:            23.2.1
+    Installed Location: /Users/k24/Library/Android/sdk/extras/android/support
+
+extras;google;m2repository
+    Description:        Google Repository
+    Version:            47
+    Installed Location: /Users/k24/Library/Android/sdk/extras/google/m2repository
+
+extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.2
+    Description:        Solver for ConstraintLayout 1.0.2
+    Version:            1
+    Installed Location: /Users/k24/Library/Android/sdk/extras/m2repository/com/android/support/constraint/constraint-layout-solver/1.0.2
+
+extras;m2repository;com;android;support;constraint;constraint-layout;1.0.2
+    Description:        ConstraintLayout for Android 1.0.2
+    Version:            1
+    Installed Location: /Users/k24/Library/Android/sdk/extras/m2repository/com/android/support/constraint/constraint-layout/1.0.2
+
+patcher;v4
+    Description:        SDK Patch Applier v4
+    Version:            1
+    Installed Location: /Users/k24/Library/Android/sdk/patcher/v4
+
+platform-tools
+    Description:        Android SDK Platform-Tools
+    Version:            26.0.0
+    Installed Location: /Users/k24/Library/Android/sdk/platform-tools
+
+platforms;android-10
+    Description:        Android SDK Platform 10, rev 2
+    Version:            2
+    Installed Location: /Users/k24/Library/Android/sdk/platforms/android-10
+
+platforms;android-16
+    Description:        Android SDK Platform 16, rev 5
+    Version:            5
+    Installed Location: /Users/k24/Library/Android/sdk/platforms/android-16
+
+platforms;android-19
+    Description:        Android SDK Platform 19, rev 4
+    Version:            4
+    Installed Location: /Users/k24/Library/Android/sdk/platforms/android-19
+
+platforms;android-21
+    Description:        Android SDK Platform 21, rev 2
+    Version:            2
+    Installed Location: /Users/k24/Library/Android/sdk/platforms/android-21
+
+platforms;android-22
+    Description:        Android SDK Platform 22, rev 2
+    Version:            2
+    Installed Location: /Users/k24/Library/Android/sdk/platforms/android-22
+
+platforms;android-23
+    Description:        Android SDK Platform 23, rev 3
+    Version:            3
+    Installed Location: /Users/k24/Library/Android/sdk/platforms/android-23
+
+platforms;android-24
+    Description:        Android SDK Platform 24, rev 2
+    Version:            2
+    Installed Location: /Users/k24/Library/Android/sdk/platforms/android-24
+
+platforms;android-25
+    Description:        Android SDK Platform 25, rev 3
+    Version:            3
+    Installed Location: /Users/k24/Library/Android/sdk/platforms/android-25
+
+platforms;android-26
+    Description:        Android SDK Platform 26
+    Version:            2
+    Installed Location: /Users/k24/Library/Android/sdk/platforms/android-26
+
+sources;android-22
+    Description:        Sources for Android 22
+    Version:            1
+    Installed Location: /Users/k24/Library/Android/sdk/sources/android-22
+
+sources;android-23
+    Description:        Sources for Android 23
+    Version:            1
+    Installed Location: /Users/k24/Library/Android/sdk/sources/android-23
+
+system-images;android-10;default;x86
+    Description:        Intel x86 Atom System Image
+    Version:            4
+    Installed Location: /Users/k24/Library/Android/sdk/system-images/android-10/default/x86
+
+system-images;android-16;default;x86
+    Description:        Intel x86 Atom System Image
+    Version:            5
+    Installed Location: /Users/k24/Library/Android/sdk/system-images/android-16/default/x86
+
+system-images;android-23;default;x86_64
+    Description:        Intel x86 Atom_64 System Image
+    Version:            9
+    Installed Location: /Users/k24/Library/Android/sdk/system-images/android-23/default/x86_64
+
+system-images;android-23;google_apis;x86_64
+    Description:        Google APIs Intel x86 Atom_64 System Image
+    Version:            17
+    Installed Location: /Users/k24/Library/Android/sdk/system-images/android-23/google_apis/x86_64
+
+system-images;android-24;default;x86_64
+    Description:        Intel x86 Atom_64 System Image
+    Version:            7
+    Installed Location: /Users/k24/Library/Android/sdk/system-images/android-24/default/x86_64
+
+system-images;android-25;google_apis;x86_64
+    Description:        Google APIs Intel x86 Atom_64 System Image
+    Version:            3
+    Installed Location: /Users/k24/Library/Android/sdk/system-images/android-25/google_apis/x86_64
+
+tools
+    Description:        Android SDK Tools
+    Version:            26.0.2
+    Installed Location: /Users/k24/Library/Android/sdk/tools
+
+Available Packages:
+--------------------------------------
+add-ons;addon-google_apis-google-15
+    Description:        Google APIs
+    Version:            3
+
+add-ons;addon-google_apis-google-16
+    Description:        Google APIs
+    Version:            4
+
+add-ons;addon-google_apis-google-17
+    Description:        Google APIs
+    Version:            4
+
+add-ons;addon-google_apis-google-18
+    Description:        Google APIs
+    Version:            4
+
+add-ons;addon-google_apis-google-19
+    Description:        Google APIs
+    Version:            20
+
+add-ons;addon-google_apis-google-21
+    Description:        Google APIs
+    Version:            1
+
+add-ons;addon-google_apis-google-22
+    Description:        Google APIs
+    Version:            1
+
+add-ons;addon-google_apis-google-23
+    Description:        Google APIs
+    Version:            1
+
+add-ons;addon-google_apis-google-24
+    Description:        Google APIs
+    Version:            1
+
+add-ons;addon-google_gdk-google-19
+    Description:        Glass Development Kit Preview
+    Version:            11
+
+build-tools;19.1.0
+    Description:        Android SDK Build-Tools 19.1
+    Version:            19.1.0
+
+build-tools;20.0.0
+    Description:        Android SDK Build-Tools 20
+    Version:            20.0.0
+
+build-tools;21.1.2
+    Description:        Android SDK Build-Tools 21.1.2
+    Version:            21.1.2
+
+build-tools;22.0.1
+    Description:        Android SDK Build-Tools 22.0.1
+    Version:            22.0.1
+
+build-tools;23.0.1
+    Description:        Android SDK Build-Tools 23.0.1
+    Version:            23.0.1
+
+build-tools;23.0.2
+    Description:        Android SDK Build-Tools 23.0.2
+    Version:            23.0.2
+
+build-tools;23.0.3
+    Description:        Android SDK Build-Tools 23.0.3
+    Version:            23.0.3
+
+build-tools;24.0.0
+    Description:        Android SDK Build-Tools 24
+    Version:            24.0.0
+
+build-tools;24.0.1
+    Description:        Android SDK Build-Tools 24.0.1
+    Version:            24.0.1
+
+build-tools;24.0.2
+    Description:        Android SDK Build-Tools 24.0.2
+    Version:            24.0.2
+
+build-tools;24.0.3
+    Description:        Android SDK Build-Tools 24.0.3
+    Version:            24.0.3
+
+build-tools;25.0.0
+    Description:        Android SDK Build-Tools 25
+    Version:            25.0.0
+
+build-tools;25.0.1
+    Description:        Android SDK Build-Tools 25.0.1
+    Version:            25.0.1
+
+build-tools;25.0.2
+    Description:        Android SDK Build-Tools 25.0.2
+    Version:            25.0.2
+
+build-tools;25.0.3
+    Description:        Android SDK Build-Tools 25.0.3
+    Version:            25.0.3
+
+build-tools;26.0.0
+    Description:        Android SDK Build-Tools 26
+    Version:            26.0.0
+
+build-tools;26.0.1
+    Description:        Android SDK Build-Tools 26.0.1
+    Version:            26.0.1
+
+build-tools;26.0.2
+    Description:        Android SDK Build-Tools 26.0.2
+    Version:            26.0.2
+
+cmake;3.6.4111459
+    Description:        CMake 3.6.4111459
+    Version:            3.6.4111459
+
+docs
+    Description:        Documentation for Android SDK
+    Version:            1
+
+emulator
+    Description:        Android Emulator
+    Version:            26.1.4
+    Dependencies:
+        patcher;v4
+        tools Revision 25.3
+
+extras;android;gapid;1
+    Description:        GPU Debugging tools
+    Version:            1.0.3
+
+extras;android;gapid;3
+    Description:        GPU Debugging tools
+    Version:            3.1.0
+
+extras;android;m2repository
+    Description:        Android Support Repository
+    Version:            47.0.0
+
+extras;google;auto
+    Description:        Android Auto Desktop Head Unit emulator
+    Version:            1.1
+
+extras;google;google_play_services
+    Description:        Google Play services
+    Version:            44
+    Dependencies:
+        patcher;v4
+
+extras;google;instantapps
+    Description:        Instant Apps Development SDK
+    Version:            1.1.0
+
+extras;google;m2repository
+    Description:        Google Repository
+    Version:            58
+    Dependencies:
+        patcher;v4
+
+extras;google;market_apk_expansion
+    Description:        Google Play APK Expansion library
+    Version:            1
+
+extras;google;market_licensing
+    Description:        Google Play Licensing Library
+    Version:            1
+
+extras;google;simulators
+    Description:        Android Auto API Simulators
+    Version:            1
+
+extras;google;webdriver
+    Description:        Google Web Driver
+    Version:            2
+
+extras;intel;Hardware_Accelerated_Execution_Manager
+    Description:        Intel x86 Emulator Accelerator (HAXM installer)
+    Version:            6.2.1
+
+extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.0
+    Description:        Solver for ConstraintLayout 1.0.0
+    Version:            1
+
+extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.0-alpha2
+    Description:        com.android.support.constraint:constraint-layout-solver:1.0.0-alpha2
+    Version:            1
+
+extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.0-alpha3
+    Description:        com.android.support.constraint:constraint-layout-solver:1.0.0-alpha3
+    Version:            1
+
+extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.0-alpha4
+    Description:        com.android.support.constraint:constraint-layout-solver:1.0.0-alpha4
+    Version:            1
+
+extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.0-alpha5
+    Description:        Solver for ConstraintLayout 1.0.0-alpha5
+    Version:            1
+
+extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.0-alpha6
+    Description:        Solver for ConstraintLayout 1.0.0-alpha6
+    Version:            1
+
+extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.0-alpha7
+    Description:        Solver for ConstraintLayout 1.0.0-alpha7
+    Version:            1
+
+extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.0-alpha8
+    Description:        Solver for ConstraintLayout 1.0.0-alpha8
+    Version:            1
+
+extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.0-alpha9
+    Description:        Solver for ConstraintLayout 1.0.0-alpha9
+    Version:            1
+
+extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.0-beta1
+    Description:        Solver for ConstraintLayout 1.0.0-beta1
+    Version:            1
+
+extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.0-beta2
+    Description:        Solver for ConstraintLayout 1.0.0-beta2
+    Version:            1
+
+extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.0-beta3
+    Description:        Solver for ConstraintLayout 1.0.0-beta3
+    Version:            1
+
+extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.0-beta4
+    Description:        Solver for ConstraintLayout 1.0.0-beta4
+    Version:            1
+
+extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.0-beta5
+    Description:        Solver for ConstraintLayout 1.0.0-beta5
+    Version:            1
+
+extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.1
+    Description:        Solver for ConstraintLayout 1.0.1
+    Version:            1
+
+extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.2
+    Description:        Solver for ConstraintLayout 1.0.2
+    Version:            1
+
+extras;m2repository;com;android;support;constraint;constraint-layout;1.0.0
+    Description:        ConstraintLayout for Android 1.0.0
+    Version:            1
+    Dependencies:
+        extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.0
+
+extras;m2repository;com;android;support;constraint;constraint-layout;1.0.0-alpha2
+    Description:        com.android.support.constraint:constraint-layout:1.0.0-alpha2
+    Version:            1
+    Dependencies:
+        extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.0-alpha2
+
+extras;m2repository;com;android;support;constraint;constraint-layout;1.0.0-alpha3
+    Description:        com.android.support.constraint:constraint-layout:1.0.0-alpha3
+    Version:            1
+    Dependencies:
+        extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.0-alpha3
+
+extras;m2repository;com;android;support;constraint;constraint-layout;1.0.0-alpha4
+    Description:        com.android.support.constraint:constraint-layout:1.0.0-alpha4
+    Version:            1
+    Dependencies:
+        extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.0-alpha4
+
+extras;m2repository;com;android;support;constraint;constraint-layout;1.0.0-alpha5
+    Description:        ConstraintLayout for Android 1.0.0-alpha5
+    Version:            1
+    Dependencies:
+        extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.0-alpha5
+
+extras;m2repository;com;android;support;constraint;constraint-layout;1.0.0-alpha6
+    Description:        ConstraintLayout for Android 1.0.0-alpha6
+    Version:            1
+    Dependencies:
+        extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.0-alpha6
+
+extras;m2repository;com;android;support;constraint;constraint-layout;1.0.0-alpha7
+    Description:        ConstraintLayout for Android 1.0.0-alpha7
+    Version:            1
+    Dependencies:
+        extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.0-alpha7
+
+extras;m2repository;com;android;support;constraint;constraint-layout;1.0.0-alpha8
+    Description:        ConstraintLayout for Android 1.0.0-alpha8
+    Version:            1
+    Dependencies:
+        extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.0-alpha8
+
+extras;m2repository;com;android;support;constraint;constraint-layout;1.0.0-alpha9
+    Description:        ConstraintLayout for Android 1.0.0-alpha9
+    Version:            1
+    Dependencies:
+        extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.0-alpha9
+
+extras;m2repository;com;android;support;constraint;constraint-layout;1.0.0-beta1
+    Description:        ConstraintLayout for Android 1.0.0-beta1
+    Version:            1
+    Dependencies:
+        extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.0-beta1
+
+extras;m2repository;com;android;support;constraint;constraint-layout;1.0.0-beta2
+    Description:        ConstraintLayout for Android 1.0.0-beta2
+    Version:            1
+    Dependencies:
+        extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.0-beta2
+
+extras;m2repository;com;android;support;constraint;constraint-layout;1.0.0-beta3
+    Description:        ConstraintLayout for Android 1.0.0-beta3
+    Version:            1
+    Dependencies:
+        extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.0-beta3
+
+extras;m2repository;com;android;support;constraint;constraint-layout;1.0.0-beta4
+    Description:        ConstraintLayout for Android 1.0.0-beta4
+    Version:            1
+    Dependencies:
+        extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.0-beta4
+
+extras;m2repository;com;android;support;constraint;constraint-layout;1.0.0-beta5
+    Description:        ConstraintLayout for Android 1.0.0-beta5
+    Version:            1
+    Dependencies:
+        extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.0-beta5
+
+extras;m2repository;com;android;support;constraint;constraint-layout;1.0.1
+    Description:        ConstraintLayout for Android 1.0.1
+    Version:            1
+    Dependencies:
+        extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.1
+
+extras;m2repository;com;android;support;constraint;constraint-layout;1.0.2
+    Description:        ConstraintLayout for Android 1.0.2
+    Version:            1
+    Dependencies:
+        extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.2
+
+lldb;2.0
+    Description:        LLDB 2.0
+    Version:            2.0.2558144
+
+lldb;2.1
+    Description:        LLDB 2.1
+    Version:            2.1.2852477
+
+lldb;2.2
+    Description:        LLDB 2.2
+    Version:            2.2.3271982
+    Dependencies:
+        patcher;v4
+
+lldb;2.3
+    Description:        LLDB 2.3
+    Version:            2.3.3614996
+    Dependencies:
+        patcher;v4
+
+ndk-bundle
+    Description:        NDK
+    Version:            15.2.4203891
+    Dependencies:
+        patcher;v4
+
+patcher;v4
+    Description:        SDK Patch Applier v4
+    Version:            1
+
+platform-tools
+    Description:        Android SDK Platform-Tools
+    Version:            26.0.1
+
+platforms;android-10
+    Description:        Android SDK Platform 10
+    Version:            2
+
+platforms;android-11
+    Description:        Android SDK Platform 11
+    Version:            2
+
+platforms;android-12
+    Description:        Android SDK Platform 12
+    Version:            3
+
+platforms;android-13
+    Description:        Android SDK Platform 13
+    Version:            1
+
+platforms;android-14
+    Description:        Android SDK Platform 14
+    Version:            4
+
+platforms;android-15
+    Description:        Android SDK Platform 15
+    Version:            5
+
+platforms;android-16
+    Description:        Android SDK Platform 16
+    Version:            5
+
+platforms;android-17
+    Description:        Android SDK Platform 17
+    Version:            3
+
+platforms;android-18
+    Description:        Android SDK Platform 18
+    Version:            3
+
+platforms;android-19
+    Description:        Android SDK Platform 19
+    Version:            4
+
+platforms;android-20
+    Description:        Android SDK Platform 20
+    Version:            2
+
+platforms;android-21
+    Description:        Android SDK Platform 21
+    Version:            2
+
+platforms;android-22
+    Description:        Android SDK Platform 22
+    Version:            2
+
+platforms;android-23
+    Description:        Android SDK Platform 23
+    Version:            3
+
+platforms;android-24
+    Description:        Android SDK Platform 24
+    Version:            2
+
+platforms;android-25
+    Description:        Android SDK Platform 25
+    Version:            3
+
+platforms;android-26
+    Description:        Android SDK Platform 26
+    Version:            2
+
+platforms;android-7
+    Description:        Android SDK Platform 7
+    Version:            3
+
+platforms;android-8
+    Description:        Android SDK Platform 8
+    Version:            3
+
+platforms;android-9
+    Description:        Android SDK Platform 9
+    Version:            2
+
+sources;android-15
+    Description:        Sources for Android 15
+    Version:            2
+
+sources;android-16
+    Description:        Sources for Android 16
+    Version:            2
+
+sources;android-17
+    Description:        Sources for Android 17
+    Version:            1
+
+sources;android-18
+    Description:        Sources for Android 18
+    Version:            1
+
+sources;android-19
+    Description:        Sources for Android 19
+    Version:            2
+
+sources;android-20
+    Description:        Sources for Android 20
+    Version:            1
+
+sources;android-21
+    Description:        Sources for Android 21
+    Version:            1
+
+sources;android-22
+    Description:        Sources for Android 22
+    Version:            1
+
+sources;android-23
+    Description:        Sources for Android 23
+    Version:            1
+
+sources;android-24
+    Description:        Sources for Android 24
+    Version:            1
+
+sources;android-25
+    Description:        Sources for Android 25
+    Version:            1
+
+system-images;android-10;default;armeabi-v7a
+    Description:        ARM EABI v7a System Image
+    Version:            4
+
+system-images;android-10;default;x86
+    Description:        Intel x86 Atom System Image
+    Version:            4
+
+system-images;android-10;google_apis;armeabi-v7a
+    Description:        Google APIs ARM EABI v7a System Image
+    Version:            5
+
+system-images;android-10;google_apis;x86
+    Description:        Google APIs Intel x86 Atom System Image
+    Version:            5
+
+system-images;android-14;default;armeabi-v7a
+    Description:        ARM EABI v7a System Image
+    Version:            2
+
+system-images;android-15;default;armeabi-v7a
+    Description:        ARM EABI v7a System Image
+    Version:            4
+    Dependencies:
+        patcher;v4
+
+system-images;android-15;default;mips
+    Description:        MIPS System Image
+    Version:            1
+
+system-images;android-15;default;x86
+    Description:        Intel x86 Atom System Image
+    Version:            4
+
+system-images;android-15;google_apis;armeabi-v7a
+    Description:        Google APIs ARM EABI v7a System Image
+    Version:            5
+
+system-images;android-15;google_apis;x86
+    Description:        Google APIs Intel x86 Atom System Image
+    Version:            5
+
+system-images;android-16;default;armeabi-v7a
+    Description:        ARM EABI v7a System Image
+    Version:            4
+
+system-images;android-16;default;mips
+    Description:        MIPS System Image
+    Version:            1
+
+system-images;android-16;default;x86
+    Description:        Intel x86 Atom System Image
+    Version:            5
+
+system-images;android-16;google_apis;armeabi-v7a
+    Description:        Google APIs ARM EABI v7a System Image
+    Version:            5
+
+system-images;android-16;google_apis;x86
+    Description:        Google APIs Intel x86 Atom System Image
+    Version:            5
+
+system-images;android-17;default;armeabi-v7a
+    Description:        ARM EABI v7a System Image
+    Version:            5
+    Dependencies:
+        patcher;v4
+
+system-images;android-17;default;mips
+    Description:        MIPS System Image
+    Version:            1
+
+system-images;android-17;default;x86
+    Description:        Intel x86 Atom System Image
+    Version:            3
+    Dependencies:
+        patcher;v4
+
+system-images;android-17;google_apis;armeabi-v7a
+    Description:        Google APIs ARM EABI v7a System Image
+    Version:            5
+
+system-images;android-17;google_apis;x86
+    Description:        Google APIs Intel x86 Atom System Image
+    Version:            5
+
+system-images;android-18;default;armeabi-v7a
+    Description:        ARM EABI v7a System Image
+    Version:            4
+    Dependencies:
+        patcher;v4
+
+system-images;android-18;default;x86
+    Description:        Intel x86 Atom System Image
+    Version:            3
+    Dependencies:
+        patcher;v4
+
+system-images;android-18;google_apis;armeabi-v7a
+    Description:        Google APIs ARM EABI v7a System Image
+    Version:            5
+
+system-images;android-18;google_apis;x86
+    Description:        Google APIs Intel x86 Atom System Image
+    Version:            5
+
+system-images;android-19;default;armeabi-v7a
+    Description:        ARM EABI v7a System Image
+    Version:            5
+    Dependencies:
+        patcher;v4
+
+system-images;android-19;default;x86
+    Description:        Intel x86 Atom System Image
+    Version:            6
+    Dependencies:
+        patcher;v4
+
+system-images;android-19;google_apis;armeabi-v7a
+    Description:        Google APIs ARM EABI v7a System Image
+    Version:            30
+    Dependencies:
+        patcher;v4
+
+system-images;android-19;google_apis;x86
+    Description:        Google APIs Intel x86 Atom System Image
+    Version:            30
+    Dependencies:
+        patcher;v4
+
+system-images;android-21;android-tv;armeabi-v7a
+    Description:        Android TV ARM EABI v7a System Image
+    Version:            3
+
+system-images;android-21;android-tv;x86
+    Description:        Android TV Intel x86 Atom System Image
+    Version:            3
+
+system-images;android-21;default;armeabi-v7a
+    Description:        ARM EABI v7a System Image
+    Version:            4
+    Dependencies:
+        patcher;v4
+
+system-images;android-21;default;x86
+    Description:        Intel x86 Atom System Image
+    Version:            5
+    Dependencies:
+        patcher;v4
+
+system-images;android-21;default;x86_64
+    Description:        Intel x86 Atom_64 System Image
+    Version:            5
+    Dependencies:
+        patcher;v4
+
+system-images;android-21;google_apis;armeabi-v7a
+    Description:        Google APIs ARM EABI v7a System Image
+    Version:            22
+    Dependencies:
+        patcher;v4
+
+system-images;android-21;google_apis;x86
+    Description:        Google APIs Intel x86 Atom System Image
+    Version:            22
+    Dependencies:
+        patcher;v4
+
+system-images;android-21;google_apis;x86_64
+    Description:        Google APIs Intel x86 Atom_64 System Image
+    Version:            22
+    Dependencies:
+        patcher;v4
+
+system-images;android-22;android-tv;armeabi-v7a
+    Description:        Android TV ARM EABI v7a System Image
+    Version:            1
+
+system-images;android-22;android-tv;x86
+    Description:        Android TV Intel x86 Atom System Image
+    Version:            3
+
+system-images;android-22;default;armeabi-v7a
+    Description:        ARM EABI v7a System Image
+    Version:            2
+    Dependencies:
+        patcher;v4
+
+system-images;android-22;default;x86
+    Description:        Intel x86 Atom System Image
+    Version:            6
+    Dependencies:
+        patcher;v4
+
+system-images;android-22;default;x86_64
+    Description:        Intel x86 Atom_64 System Image
+    Version:            6
+    Dependencies:
+        patcher;v4
+
+system-images;android-22;google_apis;armeabi-v7a
+    Description:        Google APIs ARM EABI v7a System Image
+    Version:            16
+    Dependencies:
+        patcher;v4
+
+system-images;android-22;google_apis;x86
+    Description:        Google APIs Intel x86 Atom System Image
+    Version:            16
+    Dependencies:
+        patcher;v4
+
+system-images;android-22;google_apis;x86_64
+    Description:        Google APIs Intel x86 Atom_64 System Image
+    Version:            16
+    Dependencies:
+        patcher;v4
+
+system-images;android-23;android-tv;armeabi-v7a
+    Description:        Android TV ARM EABI v7a System Image
+    Version:            11
+
+system-images;android-23;android-tv;x86
+    Description:        Android TV Intel x86 Atom System Image
+    Version:            11
+    Dependencies:
+        patcher;v4
+
+system-images;android-23;android-wear;armeabi-v7a
+    Description:        Android Wear ARM EABI v7a System Image
+    Version:            6
+    Dependencies:
+        patcher;v4
+
+system-images;android-23;android-wear;x86
+    Description:        Android Wear Intel x86 Atom System Image
+    Version:            6
+    Dependencies:
+        patcher;v4
+
+system-images;android-23;default;x86
+    Description:        Intel x86 Atom System Image
+    Version:            10
+    Dependencies:
+        patcher;v4
+
+system-images;android-23;default;x86_64
+    Description:        Intel x86 Atom_64 System Image
+    Version:            10
+    Dependencies:
+        patcher;v4
+
+system-images;android-23;google_apis;armeabi-v7a
+    Description:        Google APIs ARM EABI v7a System Image
+    Version:            23
+    Dependencies:
+        patcher;v4
+
+system-images;android-23;google_apis;x86
+    Description:        Google APIs Intel x86 Atom System Image
+    Version:            23
+    Dependencies:
+        patcher;v4
+
+system-images;android-23;google_apis;x86_64
+    Description:        Google APIs Intel x86 Atom_64 System Image
+    Version:            23
+    Dependencies:
+        patcher;v4
+
+system-images;android-24;android-tv;x86
+    Description:        Android TV Intel x86 Atom System Image
+    Version:            12
+    Dependencies:
+        patcher;v4
+
+system-images;android-24;default;arm64-v8a
+    Description:        ARM 64 v8a System Image
+    Version:            7
+
+system-images;android-24;default;armeabi-v7a
+    Description:        ARM EABI v7a System Image
+    Version:            7
+    Dependencies:
+        patcher;v4
+
+system-images;android-24;default;x86
+    Description:        Intel x86 Atom System Image
+    Version:            8
+    Dependencies:
+        patcher;v4
+
+system-images;android-24;default;x86_64
+    Description:        Intel x86 Atom_64 System Image
+    Version:            8
+    Dependencies:
+        patcher;v4
+
+system-images;android-24;google_apis;arm64-v8a
+    Description:        Google APIs ARM 64 v8a System Image
+    Version:            16
+    Dependencies:
+        patcher;v4
+
+system-images;android-24;google_apis;armeabi-v7a
+    Description:        Google APIs ARM EABI v7a System Image
+    Version:            16
+    Dependencies:
+        patcher;v4
+
+system-images;android-24;google_apis;x86
+    Description:        Google APIs Intel x86 Atom System Image
+    Version:            16
+    Dependencies:
+        patcher;v4
+
+system-images;android-24;google_apis;x86_64
+    Description:        Google APIs Intel x86 Atom_64 System Image
+    Version:            16
+    Dependencies:
+        patcher;v4
+
+system-images;android-24;google_apis_playstore;x86
+    Description:        Google Play Intel x86 Atom System Image
+    Version:            16
+    Dependencies:
+        patcher;v4
+
+system-images;android-25;android-tv;x86
+    Description:        Android TV Intel x86 Atom System Image
+    Version:            6
+    Dependencies:
+        patcher;v4
+
+system-images;android-25;android-wear;armeabi-v7a
+    Description:        Android Wear ARM EABI v7a System Image
+    Version:            3
+    Dependencies:
+        patcher;v4
+
+system-images;android-25;android-wear;x86
+    Description:        Android Wear Intel x86 Atom System Image
+    Version:            3
+    Dependencies:
+        patcher;v4
+
+system-images;android-25;google_apis;arm64-v8a
+    Description:        Google APIs ARM 64 v8a System Image
+    Version:            8
+    Dependencies:
+        patcher;v4
+
+system-images;android-25;google_apis;armeabi-v7a
+    Description:        Google APIs ARM EABI v7a System Image
+    Version:            8
+    Dependencies:
+        patcher;v4
+
+system-images;android-25;google_apis;x86
+    Description:        Google APIs Intel x86 Atom System Image
+    Version:            8
+    Dependencies:
+        patcher;v4
+
+system-images;android-25;google_apis;x86_64
+    Description:        Google APIs Intel x86 Atom_64 System Image
+    Version:            8
+    Dependencies:
+        patcher;v4
+
+system-images;android-25;google_apis_playstore;x86
+    Description:        Google Play Intel x86 Atom System Image
+    Version:            9
+    Dependencies:
+        patcher;v4
+
+system-images;android-26;android-tv;x86
+    Description:        Android TV Intel x86 Atom System Image
+    Version:            4
+    Dependencies:
+        emulator Revision 26.1.3
+
+system-images;android-26;android-wear;x86
+    Description:        Android Wear Intel x86 Atom System Image
+    Version:            2
+    Dependencies:
+        patcher;v4
+
+system-images;android-26;google_apis;x86
+    Description:        Google APIs Intel x86 Atom System Image
+    Version:            5
+    Dependencies:
+        emulator Revision 26.1.3
+
+system-images;android-26;google_apis_playstore;x86
+    Description:        Google Play Intel x86 Atom System Image
+    Version:            5
+    Dependencies:
+        emulator Revision 26.1.3
+
+tools
+    Description:        Android SDK Tools
+    Version:            26.1.1
+    Dependencies:
+        patcher;v4
+        emulator
+        platform-tools Revision 20
+
+Available Updates:
+--------------------------------------
+emulator
+    Local Version:  26.0.0
+    Remote Version: 26.1.4
+extras;google;m2repository
+    Local Version:  47
+    Remote Version: 58
+platform-tools
+    Local Version:  26.0.0
+    Remote Version: 26.0.1
+system-images;android-23;default;x86_64
+    Local Version:  9
+    Remote Version: 10
+system-images;android-23;google_apis;x86_64
+    Local Version:  17
+    Remote Version: 23
+system-images;android-24;default;x86_64
+    Local Version:  7
+    Remote Version: 8
+system-images;android-25;google_apis;x86_64
+    Local Version:  3
+    Remote Version: 8
+tools
+    Local Version:  26.0.2
+    Remote Version: 26.1.1
+done

--- a/test/sdkmanager.ts
+++ b/test/sdkmanager.ts
@@ -24,6 +24,13 @@ describe('sdkmanager', () => {
     console.log(JSON.stringify(packages, null, 2));
   });
 
+  it('parse list3', () => {
+    const stdout = getList(3);
+    const packages = sdkManager.parseList(stdout);
+
+    console.log(JSON.stringify(packages, null, 2));
+  });
+
   it('not found license', async () => {
     const sdkSetting = new AppSetting();
     sdkSetting.sdkRootPath = __dirname;


### PR DESCRIPTION
Implemented parsing Available Updates to update specific categories for me.

Screenshot:
<img width="1105" alt="screen shot 2017-10-02 at 22 00 17" src="https://user-images.githubusercontent.com/5054499/31079792-c7aef1a4-a7c1-11e7-9d10-37bd9167ac64.png">

I don't know whether this PR is compatible with 26.1.1 or not.
Feel free to close this if something inconvenient.